### PR TITLE
[fix/APT-3818] Crash uri communication

### DIFF
--- a/android-appcoins-billing/src/debug/AndroidManifest.xml
+++ b/android-appcoins-billing/src/debug/AndroidManifest.xml
@@ -27,5 +27,16 @@
     <activity
         android:name="com.appcoins.sdk.billing.WebViewActivity"
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen"/>
+        <activity android:name="com.appcoins.sdk.billing.UriCommunicationActivity"
+            android:exported="true">
+          <intent-filter>
+            <action android:name="android.intent.action.VIEW"/>
+            <data
+                android:host="billing"
+                android:path="/communication/requester/1"
+                android:scheme="appcoins"/>
+            <category android:name="android.intent.category.DEFAULT"/>
+          </intent-filter>
+        </activity>
   </application>
 </manifest>

--- a/android-appcoins-billing/src/main/AndroidManifest.xml
+++ b/android-appcoins-billing/src/main/AndroidManifest.xml
@@ -24,5 +24,16 @@
     <activity
         android:name="com.appcoins.sdk.billing.WebViewActivity"
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen"/>
+    <activity android:name="com.appcoins.sdk.billing.UriCommunicationActivity"
+        android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW"/>
+        <data
+            android:host="billing"
+            android:path="/communication/requester/1"
+            android:scheme="appcoins"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+      </intent-filter>
+    </activity>
   </application>
 </manifest>

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/UriCommunicationActivity.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/UriCommunicationActivity.kt
@@ -1,0 +1,5 @@
+package com.appcoins.sdk.billing
+
+import com.appcoins.communication.requester.MessageRequesterActivity
+
+class UriCommunicationActivity : MessageRequesterActivity()

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/AppcoinsBillingStubHelper.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/AppcoinsBillingStubHelper.java
@@ -348,15 +348,12 @@ public final class AppcoinsBillingStubHelper implements AppcoinsBilling, Seriali
                 SharedPreferencesRepository.TTL_IN_SECONDS);
         AppcoinsBilling appcoinsBilling;
         if (WalletBinderUtil.getBindType() == BindType.URI_CONNECTION) {
-          String priorityPackage = BuildConfig.APPCOINS_WALLET_PACKAGE_NAME;
-          if (!WalletUtils.getPayflowMethodsList().isEmpty()) {
-            priorityPackage = WalletUtils.getPayflowMethodsList().get(0).getName();
-          }
-          SyncIpcMessageRequester messageRequester =
-              MessageRequesterFactory.create(WalletUtils.getLifecycleActivityProvider(),
-                  priorityPackage, "appcoins://billing/communication/processor/1",
-                  "appcoins://billing/communication/requester/1", BdsService.TIME_OUT_IN_MILLIS);
-          appcoinsBilling = new UriCommunicationAppcoinsBilling(messageRequester);
+            SyncIpcMessageRequester messageRequester =
+                MessageRequesterFactory.create(WalletUtils.getLifecycleActivityProvider(),
+                    BuildConfig.APPCOINS_WALLET_PACKAGE_NAME,
+                    "appcoins://billing/communication/processor/1",
+                    "appcoins://billing/communication/requester/1", BdsService.TIME_OUT_IN_MILLIS);
+            appcoinsBilling = new UriCommunicationAppcoinsBilling(messageRequester);
         } else {
           appcoinsBilling = AppcoinsBilling.Stub.asInterface(service);
         }


### PR DESCRIPTION
**What does this PR do?**

   The default communication is through AIDL, but the the Uri communication should be called in case the binding of the AIDL services fails, in which case the Uri communication should be handles in the manifest to call the MessageRequesterActivity

**Database changed?**

   No

**What are the relevant tickets?**

  Tickets related to this pull-request: [APT-3818](https://aptoide.atlassian.net/browse/APT-3818)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 



**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass