### PR TITLE
Add retry mechanism for Attribution request on failure case

### DIFF
--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/analytics/AnalyticsContent.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/analytics/AnalyticsContent.kt
@@ -66,6 +66,7 @@ object SdkAnalyticsFailureLabels {
     const val SDK_WEB_PAYMENT_URL_GENERATION_FAILED = "sdk_web_payment_url_generation_failed"
     const val SDK_BACKEND_GUEST_UID_GENERATION_FAILED = "sdk_backend_guest_uid_generation_failed"
     const val SDK_WEB_VIEW_RESULT_FAILED = "sdk_web_view_result_failed"
+    const val ATTRIBUTION_RETRY_ATTEMPT = "attribution_retry_attempt"
 }
 
 object SdkUpdateFlowActions {

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/analytics/SdkAnalytics.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/analytics/SdkAnalytics.kt
@@ -232,6 +232,12 @@ class SdkAnalytics(private val analyticsManager: AnalyticsManager) : Serializabl
         )
     }
 
+    fun sendAttributionRetryAttemptEvent(failureMessage: String) =
+        sendEmptyUnexpectedFailureEvent(
+            SdkAnalyticsFailureLabels.ATTRIBUTION_RETRY_ATTEMPT,
+            failureMessage
+        )
+
     fun sendUnsuccessfulWebViewResultEvent(failureMessage: String) =
         sendEmptyUnexpectedFailureEvent(
             SdkAnalyticsFailureLabels.SDK_WEB_VIEW_RESULT_FAILED,

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/managers/AttributionManager.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/managers/AttributionManager.kt
@@ -15,7 +15,7 @@ import com.appcoins.sdk.billing.utils.AppcoinsBillingConstants.TIMEOUT_30_SECS
 import com.appcoins.sdk.billing.utils.ServiceUtils.isSuccess
 import com.appcoins.sdk.core.logger.Logger.logError
 import com.appcoins.sdk.core.logger.Logger.logInfo
-import com.appcoins.sdk.core.retrymechanism.IncompleteCircularFunctionExecutionException
+import com.appcoins.sdk.core.retrymechanism.exceptions.IncompleteCircularFunctionExecutionException
 import com.appcoins.sdk.core.retrymechanism.retryUntilSuccess
 
 object AttributionManager {

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/managers/BillingLifecycleManager.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/managers/BillingLifecycleManager.kt
@@ -17,15 +17,15 @@ object BillingLifecycleManager {
         Thread {
             AttributionManager.getAttributionForUser {
                 PayflowManager.getPayflowPriorityAsync()
-                val receiverIntentFilter = IntentFilter()
-                receiverIntentFilter.addAction(Intent.ACTION_PACKAGE_ADDED)
-                receiverIntentFilter.addAction(Intent.ACTION_PACKAGE_REMOVED)
-                receiverIntentFilter.addDataScheme(PACKAGE_SCHEME)
-                context.applicationContext.registerReceiver(
-                    appInstallationReceiver,
-                    receiverIntentFilter
-                )
             }
+            val receiverIntentFilter = IntentFilter()
+            receiverIntentFilter.addAction(Intent.ACTION_PACKAGE_ADDED)
+            receiverIntentFilter.addAction(Intent.ACTION_PACKAGE_REMOVED)
+            receiverIntentFilter.addDataScheme(PACKAGE_SCHEME)
+            context.applicationContext.registerReceiver(
+                appInstallationReceiver,
+                receiverIntentFilter
+            )
         }.start()
     }
 

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/managers/BillingLifecycleManager.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/managers/BillingLifecycleManager.kt
@@ -15,16 +15,17 @@ object BillingLifecycleManager {
     @JvmStatic
     fun setupBillingService(context: Context) {
         Thread {
-            AttributionManager.getAttributionForUser()
-            PayflowManager.getPayflowPriorityAsync()
-            val receiverIntentFilter = IntentFilter()
-            receiverIntentFilter.addAction(Intent.ACTION_PACKAGE_ADDED)
-            receiverIntentFilter.addAction(Intent.ACTION_PACKAGE_REMOVED)
-            receiverIntentFilter.addDataScheme(PACKAGE_SCHEME)
-            context.applicationContext.registerReceiver(
-                appInstallationReceiver,
-                receiverIntentFilter
-            )
+            AttributionManager.getAttributionForUser {
+                PayflowManager.getPayflowPriorityAsync()
+                val receiverIntentFilter = IntentFilter()
+                receiverIntentFilter.addAction(Intent.ACTION_PACKAGE_ADDED)
+                receiverIntentFilter.addAction(Intent.ACTION_PACKAGE_REMOVED)
+                receiverIntentFilter.addDataScheme(PACKAGE_SCHEME)
+                context.applicationContext.registerReceiver(
+                    appInstallationReceiver,
+                    receiverIntentFilter
+                )
+            }
         }.start()
     }
 

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/repositories/AttributionRepository.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/repositories/AttributionRepository.kt
@@ -15,6 +15,7 @@ class AttributionRepository(private val bdsService: BdsService) {
         packageName: String,
         oemId: String?,
         guestWalletId: String?,
+        initialAttributionTimestamp: Long,
     ): AttributionResponse? {
         val countDownLatch = CountDownLatch(1)
         var attributionResponse: AttributionResponse? = null
@@ -23,6 +24,7 @@ class AttributionRepository(private val bdsService: BdsService) {
         queries["package_name"] = packageName
         oemId?.let { queries["oemid"] = it }
         guestWalletId?.let { queries["guest_uid"] = it }
+        queries["timestamp"] = initialAttributionTimestamp.toString()
 
         val serviceResponseListener =
             ServiceResponseListener { requestResponse ->

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/sharedpreferences/AttributionSharedPreferences.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/sharedpreferences/AttributionSharedPreferences.kt
@@ -13,6 +13,7 @@ class AttributionSharedPreferences(context: Context) : SharedPreferencesReposito
     fun getUtmTerm(): String? = getString(UTM_TERM_KEY)
     fun getUtmContent(): String? = getString(UTM_CONTENT_KEY)
     fun isAttributionComplete(): Boolean = getBoolean(ATTRIBUTION_COMPLETE_KEY)
+    fun getInitialAttributionTimestamp(): Long = getLong(INITIAL_ATTRIBUTION_TIMESTAMP_KEY)
 
     fun setWalletId(value: String? = null) = setString(WALLET_ID_KEY, value)
     fun setOemId(value: String? = null) = setString(OEM_ID_KEY, value)
@@ -22,6 +23,7 @@ class AttributionSharedPreferences(context: Context) : SharedPreferencesReposito
     fun setUtmTerm(value: String? = null) = setString(UTM_TERM_KEY, value)
     fun setUtmContent(value: String? = null) = setString(UTM_CONTENT_KEY, value)
     fun completeAttribution() = setBoolean(ATTRIBUTION_COMPLETE_KEY, true)
+    fun setInitialAttributionTimestamp(value: Long) = setLong(INITIAL_ATTRIBUTION_TIMESTAMP_KEY, value)
 
     private companion object {
         const val WALLET_ID_KEY = "WALLET_ID"
@@ -32,5 +34,6 @@ class AttributionSharedPreferences(context: Context) : SharedPreferencesReposito
         const val UTM_TERM_KEY = "UTM_TERM"
         const val UTM_CONTENT_KEY = "UTM_CONTENT"
         const val ATTRIBUTION_COMPLETE_KEY = "ATTRIBUTION_COMPLETE"
+        const val INITIAL_ATTRIBUTION_TIMESTAMP_KEY = "INITIAL_ATTRIBUTION_TIMESTAMP"
     }
 }

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/usecases/SaveInitialAttributionTimestamp.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/usecases/SaveInitialAttributionTimestamp.kt
@@ -1,0 +1,17 @@
+package com.appcoins.sdk.billing.usecases
+
+import com.appcoins.sdk.billing.helpers.WalletUtils
+import com.appcoins.sdk.billing.sharedpreferences.AttributionSharedPreferences
+
+object SaveInitialAttributionTimestamp : UseCase() {
+    private val attributionSharedPreferences by lazy {
+        AttributionSharedPreferences(WalletUtils.context)
+    }
+
+    operator fun invoke() {
+        super.invokeUseCase()
+        if (attributionSharedPreferences.getInitialAttributionTimestamp() == 0L) {
+            attributionSharedPreferences.setInitialAttributionTimestamp(System.currentTimeMillis())
+        }
+    }
+}

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/usecases/SendAttributionRetryAttempt.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/usecases/SendAttributionRetryAttempt.kt
@@ -1,0 +1,25 @@
+package com.appcoins.sdk.billing.usecases
+
+import com.appcoins.sdk.billing.helpers.WalletUtils
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object SendAttributionRetryAttempt : UseCase() {
+
+    operator fun invoke(attempts: Int, timestamp: Long) {
+        super.invokeUseCase()
+
+        val initialDate = Date(timestamp)
+        val currentDate = Date(System.currentTimeMillis())
+
+        val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+
+        val message =
+            "Attempting to request Attribution for $attempts attempt. " +
+                "Initial date of Attribution: ${formatter.format(initialDate)}. " +
+                "Current date: ${formatter.format(currentDate)}."
+
+        WalletUtils.getSdkAnalytics().sendAttributionRetryAttemptEvent(message)
+    }
+}

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/retrymechanism/IncompleteCircularFunctionExecutionException.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/retrymechanism/IncompleteCircularFunctionExecutionException.kt
@@ -1,0 +1,3 @@
+package com.appcoins.sdk.core.retrymechanism
+
+class IncompleteCircularFunctionExecutionException(message: String) : Exception(message)

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/retrymechanism/RetryHandler.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/retrymechanism/RetryHandler.kt
@@ -1,0 +1,38 @@
+package com.appcoins.sdk.core.retrymechanism
+
+import com.appcoins.sdk.core.logger.Logger.logError
+import com.appcoins.sdk.core.logger.Logger.logInfo
+
+fun <T> retryUntilSuccess(
+    retries: Int? = null,
+    initialInterval: Long = 1000,
+    exponentialBackoff: Boolean = false,
+    maxInterval: Long = Long.MAX_VALUE,
+    block: () -> T
+): T? {
+    var retriesLeft = retries
+    var interval = initialInterval
+    var attempt = 0
+
+    while (retriesLeft?.let { it > 0 } != false) {
+        try {
+            return block()
+        } catch (e: IncompleteCircularFunctionExecutionException) {
+            attempt++
+            if (retriesLeft != null) {
+                retriesLeft--
+            }
+
+            logError("Attempt $attempt failed: ${e.message}")
+            logInfo("Retrying in $interval milliseconds...")
+
+            Thread.sleep(interval)
+
+            if (exponentialBackoff) {
+                interval = (interval * 2).coerceAtMost(maxInterval)
+            }
+        }
+    }
+
+    throw Exception("Max retries exhausted")
+}

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/retrymechanism/RetryHandler.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/retrymechanism/RetryHandler.kt
@@ -2,6 +2,8 @@ package com.appcoins.sdk.core.retrymechanism
 
 import com.appcoins.sdk.core.logger.Logger.logError
 import com.appcoins.sdk.core.logger.Logger.logInfo
+import com.appcoins.sdk.core.retrymechanism.exceptions.IncompleteCircularFunctionExecutionException
+import com.appcoins.sdk.core.retrymechanism.exceptions.MaxAttemptsReachedException
 
 fun <T> retryUntilSuccess(
     retries: Int? = null,
@@ -34,5 +36,5 @@ fun <T> retryUntilSuccess(
         }
     }
 
-    throw Exception("Max retries exhausted")
+    throw MaxAttemptsReachedException()
 }

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/retrymechanism/RetryHandler.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/retrymechanism/RetryHandler.kt
@@ -10,7 +10,8 @@ fun <T> retryUntilSuccess(
     initialInterval: Long = 1000,
     exponentialBackoff: Boolean = false,
     maxInterval: Long = Long.MAX_VALUE,
-    block: () -> T
+    runningBlock: () -> T,
+    onRetryBlock: (attempts: Int) -> Unit
 ): T? {
     var retriesLeft = retries
     var interval = initialInterval
@@ -18,7 +19,7 @@ fun <T> retryUntilSuccess(
 
     while (retriesLeft?.let { it > 0 } != false) {
         try {
-            return block()
+            return runningBlock()
         } catch (e: IncompleteCircularFunctionExecutionException) {
             attempt++
             if (retriesLeft != null) {
@@ -27,6 +28,8 @@ fun <T> retryUntilSuccess(
 
             logError("Attempt $attempt failed: ${e.message}")
             logInfo("Retrying in $interval milliseconds...")
+
+            onRetryBlock(attempt)
 
             Thread.sleep(interval)
 

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/retrymechanism/exceptions/IncompleteCircularFunctionExecutionException.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/retrymechanism/exceptions/IncompleteCircularFunctionExecutionException.kt
@@ -1,3 +1,3 @@
-package com.appcoins.sdk.core.retrymechanism
+package com.appcoins.sdk.core.retrymechanism.exceptions
 
 class IncompleteCircularFunctionExecutionException(message: String) : Exception(message)

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/retrymechanism/exceptions/MaxAttemptsReachedException.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/retrymechanism/exceptions/MaxAttemptsReachedException.kt
@@ -1,0 +1,3 @@
+package com.appcoins.sdk.core.retrymechanism.exceptions
+
+class MaxAttemptsReachedException : Exception()


### PR DESCRIPTION
**What does this PR do?**

In this PR I've added a retry mechanism for the Attribution request when it fails.
This retry mechanism is done on an exponential time increase up until 1 minute until the response is successful.
Also added a new type of failure `ATTRIBUTION_RETRY_ATTEMPT` for the Indicative event `SDK_UNEXPECTED_FAILURE`. This failure contains the initial Timestamp of the Attribution request and the current Timestamp.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APT-4332](https://aptoide.atlassian.net/browse/APT-4332)

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.) 




**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass