### PR TITLE
Add retry mechanism for MMP Purchase event

### DIFF
--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/analytics/AnalyticsContent.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/analytics/AnalyticsContent.kt
@@ -67,6 +67,7 @@ object SdkAnalyticsFailureLabels {
     const val SDK_BACKEND_GUEST_UID_GENERATION_FAILED = "sdk_backend_guest_uid_generation_failed"
     const val SDK_WEB_VIEW_RESULT_FAILED = "sdk_web_view_result_failed"
     const val ATTRIBUTION_RETRY_ATTEMPT = "attribution_retry_attempt"
+    const val SDK_BACKEND_REQUEST_FAILED = "sdk_backend_request_failed"
 }
 
 object SdkUpdateFlowActions {

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/analytics/SdkAnalytics.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/analytics/SdkAnalytics.kt
@@ -250,6 +250,14 @@ class SdkAnalytics(private val analyticsManager: AnalyticsManager) : Serializabl
     fun sendBackendGuestUidGenerationFailedEvent() =
         sendEmptyUnexpectedFailureEvent(SdkAnalyticsFailureLabels.SDK_BACKEND_GUEST_UID_GENERATION_FAILED)
 
+    fun sendUnsuccessfulBackendRequestEvent(endpoint: String, failureMessage: String) {
+        val message = "Failed to make request to the endpoint - $endpoint. Cause - $failureMessage"
+        sendEmptyUnexpectedFailureEvent(
+            SdkAnalyticsFailureLabels.SDK_BACKEND_REQUEST_FAILED,
+            message
+        )
+    }
+
     private fun sendEmptyUnexpectedFailureEvent(
         failureType: String,
         failureMessage: String? = null

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/AppCoinsAndroidBillingRepository.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/AppCoinsAndroidBillingRepository.java
@@ -14,7 +14,6 @@ import com.appcoins.sdk.billing.SkuDetailsResult;
 import com.appcoins.sdk.billing.exceptions.ServiceConnectionException;
 import com.appcoins.sdk.billing.listeners.AppCoinsBillingStateListener;
 import com.appcoins.sdk.billing.service.WalletBillingService;
-import com.appcoins.sdk.billing.sharedpreferences.BackendRequestsSharedPreferences;
 import com.appcoins.sdk.billing.usecases.RetryFailedRequests;
 import java.util.List;
 
@@ -40,7 +39,7 @@ class AppCoinsAndroidBillingRepository implements Repository, ConnectionLifeCycl
             .getCanonicalName()));
         this.service = new WalletBillingService(service, name.getClassName());
         isServiceReady = true;
-        RetryFailedRequests.INSTANCE.invoke(new BackendRequestsSharedPreferences(WalletUtils.context));
+        RetryFailedRequests.INSTANCE.invoke();
         logInfo("Billing Connected, notifying client onBillingSetupFinished(ResponseCode.OK)");
         listener.onBillingSetupFinished(ResponseCode.OK.getValue());
     }

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/AppCoinsAndroidBillingRepository.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/AppCoinsAndroidBillingRepository.java
@@ -14,6 +14,8 @@ import com.appcoins.sdk.billing.SkuDetailsResult;
 import com.appcoins.sdk.billing.exceptions.ServiceConnectionException;
 import com.appcoins.sdk.billing.listeners.AppCoinsBillingStateListener;
 import com.appcoins.sdk.billing.service.WalletBillingService;
+import com.appcoins.sdk.billing.sharedpreferences.BackendRequestsSharedPreferences;
+import com.appcoins.sdk.billing.usecases.RetryFailedRequests;
 import java.util.List;
 
 import static com.appcoins.sdk.core.logger.Logger.logDebug;
@@ -38,6 +40,7 @@ class AppCoinsAndroidBillingRepository implements Repository, ConnectionLifeCycl
             .getCanonicalName()));
         this.service = new WalletBillingService(service, name.getClassName());
         isServiceReady = true;
+        RetryFailedRequests.INSTANCE.invoke(new BackendRequestsSharedPreferences(WalletUtils.context));
         logInfo("Billing Connected, notifying client onBillingSetupFinished(ResponseCode.OK)");
         listener.onBillingSetupFinished(ResponseCode.OK.getValue());
     }

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/AppcoinsBillingWrapper.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/helpers/AppcoinsBillingWrapper.java
@@ -77,12 +77,14 @@ class AppcoinsBillingWrapper implements AppcoinsBilling, Serializable {
     @Override
     public int consumePurchase(int apiVersion, String packageName, String purchaseToken) throws RemoteException {
         int responseCode = appcoinsBilling.consumePurchase(apiVersion, packageName, purchaseToken);
-        int guestResponseCode = consumeGuestPurchase(walletId, apiVersion, packageName, purchaseToken);
-        if (responseCode == ResponseCode.OK.getValue() || guestResponseCode == ResponseCode.OK.getValue()) {
+        if (responseCode == ResponseCode.OK.getValue()) {
             return ResponseCode.OK.getValue();
-        } else {
-            return ResponseCode.ERROR.getValue();
         }
+        int guestResponseCode = consumeGuestPurchase(walletId, apiVersion, packageName, purchaseToken);
+        if (guestResponseCode == ResponseCode.OK.getValue()) {
+            return ResponseCode.OK.getValue();
+        }
+        return ResponseCode.ERROR.getValue();
     }
 
     @Override

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/managers/MMPEventsManager.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/managers/MMPEventsManager.kt
@@ -4,18 +4,28 @@ import com.appcoins.billing.sdk.BuildConfig
 import com.appcoins.sdk.billing.Purchase
 import com.appcoins.sdk.billing.helpers.WalletUtils
 import com.appcoins.sdk.billing.repositories.MMPEventsRepository
+import com.appcoins.sdk.billing.service.BdsRetryService
 import com.appcoins.sdk.billing.service.BdsService
 import com.appcoins.sdk.billing.sharedpreferences.AttributionSharedPreferences
+import com.appcoins.sdk.billing.sharedpreferences.BackendRequestsSharedPreferences
 import com.appcoins.sdk.billing.utils.AppcoinsBillingConstants.TIMEOUT_30_SECS
 import com.appcoins.sdk.core.logger.Logger.logInfo
 
 object MMPEventsManager {
     private val packageName by lazy { WalletUtils.context.packageName }
     private val mmpEventsRepository by lazy {
-        MMPEventsRepository(BdsService(BuildConfig.MMP_BASE_HOST, TIMEOUT_30_SECS))
+        MMPEventsRepository(
+            BdsRetryService(
+                BdsService(BuildConfig.MMP_BASE_HOST, TIMEOUT_30_SECS),
+                backendRequestsSharedPreferences
+            )
+        )
     }
     private val attributionSharedPreferences by lazy {
         AttributionSharedPreferences(WalletUtils.context)
+    }
+    private val backendRequestsSharedPreferences by lazy {
+        BackendRequestsSharedPreferences(WalletUtils.context)
     }
 
     fun sendSuccessfulPurchaseResultEvent(

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/repositories/MMPEventsRepository.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/repositories/MMPEventsRepository.kt
@@ -1,8 +1,8 @@
 package com.appcoins.sdk.billing.repositories
 
-import com.appcoins.sdk.billing.service.BdsService
+import com.appcoins.sdk.billing.service.BdsRetryService
 
-class MMPEventsRepository(private val bdsService: BdsService) {
+class MMPEventsRepository(private val bdsRetryService: BdsRetryService) {
 
     fun sendSuccessfulPurchaseResultEvent(
         packageName: String,
@@ -30,13 +30,13 @@ class MMPEventsRepository(private val bdsService: BdsService) {
         utmTerm?.let { queries["utm_term"] = it }
         utmContent?.let { queries["utm_content"] = it }
 
-        bdsService.makeRequest(
+        bdsRetryService.makeRequest(
             "/purchase",
             "GET",
-            emptyList(),
+            mutableListOf(),
             queries,
-            emptyMap(),
-            emptyMap(),
+            mutableMapOf(),
+            mutableMapOf(),
             null
         )
     }

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/repositories/MMPEventsRepository.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/repositories/MMPEventsRepository.kt
@@ -24,6 +24,7 @@ class MMPEventsRepository(private val bdsRetryService: BdsRetryService) {
         queries["sku"] = sku
         queries["order_id"] = orderId
         queries["purchase_amount"] = purchaseAmount
+        queries["timestamp"] = System.currentTimeMillis().toString()
         utmSource?.let { queries["utm_source"] = it }
         utmMedium?.let { queries["utm_medium"] = it }
         utmCampaign?.let { queries["utm_campaign"] = it }

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/service/BdsRetryService.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/service/BdsRetryService.kt
@@ -1,0 +1,67 @@
+package com.appcoins.sdk.billing.service
+
+import com.appcoins.sdk.billing.sharedpreferences.BackendRequestsSharedPreferences
+import com.appcoins.sdk.billing.utils.ServiceUtils.isSuccess
+
+class BdsRetryService(
+    private val bdsService: BdsService,
+    private val sharedPreferences: BackendRequestsSharedPreferences
+) : Service {
+
+    override fun makeRequest(
+        endPoint: String,
+        httpMethod: String,
+        paths: List<String>,
+        queries: Map<String, String>,
+        header: Map<String, String>,
+        body: Map<String, Any>,
+        serviceResponseListener: ServiceResponseListener?
+    ) {
+        val serviceAsyncTaskExecutorAsync =
+            ServiceAsyncTaskExecutorAsync(
+                bdsService,
+                bdsService.baseUrl,
+                endPoint + "ss",
+                httpMethod,
+                paths,
+                queries,
+                header,
+                body
+            ) {
+                serviceResponseListener?.onResponseReceived(it)
+                if (!isSuccess(it.responseCode)) {
+                    saveFailedRequest(
+                        bdsService.baseUrl,
+                        bdsService.timeoutInMillis,
+                        endPoint,
+                        httpMethod,
+                        paths,
+                        queries,
+                        header,
+                        body
+                    )
+                }
+            }
+        serviceAsyncTaskExecutorAsync.execute()
+    }
+
+    private fun saveFailedRequest(
+        baseUrl: String,
+        timeoutInMillis: Int,
+        endPoint: String?,
+        httpMethod: String,
+        paths: List<String>,
+        queries: Map<String, String>,
+        header: Map<String, String>,
+        body: Map<String, Any>
+    ) {
+        val failedRequests = getFailedRequests()?.toMutableList() ?: mutableListOf()
+        val requestData = RequestData(baseUrl, timeoutInMillis, endPoint, httpMethod, paths, queries, header, body)
+        failedRequests.add(requestData)
+        sharedPreferences.setFailedRequests(failedRequests)
+    }
+
+    private fun getFailedRequests(): List<RequestData>? {
+        return sharedPreferences.getFailedRequests()
+    }
+}

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/service/BdsRetryService.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/service/BdsRetryService.kt
@@ -21,7 +21,7 @@ class BdsRetryService(
             ServiceAsyncTaskExecutorAsync(
                 bdsService,
                 bdsService.baseUrl,
-                endPoint + "ss",
+                endPoint,
                 httpMethod,
                 paths,
                 queries,

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/service/BdsService.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/service/BdsService.java
@@ -20,8 +20,8 @@ import static com.appcoins.sdk.core.logger.Logger.logError;
 public class BdsService implements Service {
 
     public static final int TIME_OUT_IN_MILLIS = 30000;
-    private final String baseUrl;
-    private final int timeoutInMillis;
+    public final String baseUrl;
+    public final int timeoutInMillis;
 
     public BdsService(String baseUrl, int timeoutInMillis) {
         this.baseUrl = baseUrl;

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/service/BdsService.java
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/service/BdsService.java
@@ -47,11 +47,16 @@ public class BdsService implements Service {
             InputStream inputStream;
             if (responseCode >= 400) {
                 inputStream = urlConnection.getErrorStream();
+                WalletUtils.getSdkAnalytics()
+                    .sendUnsuccessfulBackendRequestEvent(baseUrl + endPoint,
+                        urlConnection.getResponseCode() + " " + urlConnection.getResponseMessage());
             } else {
                 inputStream = urlConnection.getInputStream();
             }
             return readResponse(inputStream, responseCode);
         } catch (Exception firstException) {
+            WalletUtils.getSdkAnalytics()
+                .sendUnsuccessfulBackendRequestEvent(baseUrl + endPoint, firstException.toString());
             return handleException(urlConnection, firstException);
         } finally {
             if (urlConnection != null) {

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/service/RequestData.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/service/RequestData.kt
@@ -1,0 +1,24 @@
+package com.appcoins.sdk.billing.service
+
+import java.io.Serializable
+
+/**
+ * @param baseUrl Base URL to which the request will be performed.
+ * @param timeoutInMillis Timeout for the Request.
+ * @param endPoint Endpoint after the Base URL to which the request will be performed.
+ * @param httpMethod HTTP Method to be used in the request.
+ * @param paths List of the Paths to add to the request.
+ * @param queries List of the Queries to add to the request.
+ * @param header List of the Headers to add to the request.
+ * @param body Body to add to the request.
+ */
+class RequestData(
+    val baseUrl: String,
+    val timeoutInMillis: Int,
+    val endPoint: String?,
+    val httpMethod: String,
+    val paths: List<String>,
+    val queries: Map<String, String>,
+    val header: Map<String, String>,
+    val body: Map<String, Any>,
+) : Serializable

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/sharedpreferences/BackendRequestsSharedPreferences.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/sharedpreferences/BackendRequestsSharedPreferences.kt
@@ -1,0 +1,43 @@
+package com.appcoins.sdk.billing.sharedpreferences
+
+import android.content.Context
+import android.util.Base64
+import com.appcoins.sdk.billing.service.RequestData
+import com.appcoins.sdk.core.logger.Logger.logError
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+
+class BackendRequestsSharedPreferences(context: Context) : SharedPreferencesRepository(context) {
+
+    fun getFailedRequests(): List<RequestData>? {
+        val serializedList = getString(FAILED_REQUESTS_KEY)
+        return if (serializedList != null) {
+            try {
+                val bytes = Base64.decode(serializedList, Base64.DEFAULT)
+                ObjectInputStream(ByteArrayInputStream(bytes)).use { it.readObject() as? List<RequestData> }
+            } catch (e: Exception) {
+                logError("There was an error getting the Failed Requests.", e)
+                null
+            }
+        } else {
+            null
+        }
+    }
+
+    fun setFailedRequests(value: List<RequestData>? = null) {
+        try {
+            val byteArrayOutputStream = ByteArrayOutputStream()
+            ObjectOutputStream(byteArrayOutputStream).use { it.writeObject(value) }
+            val serializedList = Base64.encodeToString(byteArrayOutputStream.toByteArray(), Base64.DEFAULT)
+            setString(FAILED_REQUESTS_KEY, serializedList)
+        } catch (e: Exception) {
+            logError("There was an error setting the Failed Requests.", e)
+        }
+    }
+
+    private companion object {
+        const val FAILED_REQUESTS_KEY = "FAILED_REQUESTS"
+    }
+}

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/sharedpreferences/BackendRequestsSharedPreferences.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/sharedpreferences/BackendRequestsSharedPreferences.kt
@@ -27,6 +27,10 @@ class BackendRequestsSharedPreferences(context: Context) : SharedPreferencesRepo
     }
 
     fun setFailedRequests(value: List<RequestData>? = null) {
+        if (value.isNullOrEmpty()) {
+            setString(FAILED_REQUESTS_KEY, null)
+            return
+        }
         try {
             val byteArrayOutputStream = ByteArrayOutputStream()
             ObjectOutputStream(byteArrayOutputStream).use { it.writeObject(value) }

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/usecases/RetryFailedRequests.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/usecases/RetryFailedRequests.kt
@@ -1,0 +1,33 @@
+package com.appcoins.sdk.billing.usecases
+
+import com.appcoins.sdk.billing.service.BdsService
+import com.appcoins.sdk.billing.sharedpreferences.BackendRequestsSharedPreferences
+import com.appcoins.sdk.billing.utils.ServiceUtils.isSuccess
+
+object RetryFailedRequests : UseCase() {
+    operator fun invoke(sharedPreferences: BackendRequestsSharedPreferences) {
+        super.invokeUseCase()
+
+        val failedRequests = sharedPreferences.getFailedRequests()?.toMutableList()
+
+        failedRequests?.iterator()?.let { iterator ->
+            while (iterator.hasNext()) {
+                val request = iterator.next()
+                val newBdsService = BdsService(request.baseUrl, request.timeoutInMillis)
+                newBdsService.makeRequest(
+                    request.endPoint,
+                    request.httpMethod,
+                    request.paths,
+                    request.queries,
+                    request.header,
+                    request.body
+                ) { requestResponse ->
+                    if (isSuccess(requestResponse.responseCode)) {
+                        failedRequests.remove(request)
+                        sharedPreferences.setFailedRequests(failedRequests)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/usecases/RetryFailedRequests.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/usecases/RetryFailedRequests.kt
@@ -1,14 +1,20 @@
 package com.appcoins.sdk.billing.usecases
 
+import com.appcoins.sdk.billing.helpers.WalletUtils
 import com.appcoins.sdk.billing.service.BdsService
 import com.appcoins.sdk.billing.sharedpreferences.BackendRequestsSharedPreferences
 import com.appcoins.sdk.billing.utils.ServiceUtils.isSuccess
 
 object RetryFailedRequests : UseCase() {
-    operator fun invoke(sharedPreferences: BackendRequestsSharedPreferences) {
+
+    private val backendRequestsSharedPreferences: BackendRequestsSharedPreferences by lazy {
+        BackendRequestsSharedPreferences(WalletUtils.context)
+    }
+
+    operator fun invoke() {
         super.invokeUseCase()
 
-        val failedRequests = sharedPreferences.getFailedRequests()?.toMutableList()
+        val failedRequests = backendRequestsSharedPreferences.getFailedRequests()?.toMutableList()
 
         failedRequests?.iterator()?.let { iterator ->
             while (iterator.hasNext()) {
@@ -24,7 +30,7 @@ object RetryFailedRequests : UseCase() {
                 ) { requestResponse ->
                     if (isSuccess(requestResponse.responseCode)) {
                         failedRequests.remove(request)
-                        sharedPreferences.setFailedRequests(failedRequests)
+                        backendRequestsSharedPreferences.setFailedRequests(failedRequests)
                     }
                 }
             }

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/usecases/mmp/SendSuccessfulPurchaseResponseEvent.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/usecases/mmp/SendSuccessfulPurchaseResponseEvent.kt
@@ -1,24 +1,44 @@
 package com.appcoins.sdk.billing.usecases.mmp
 
 import com.appcoins.sdk.billing.Purchase
+import com.appcoins.sdk.billing.helpers.WalletUtils
 import com.appcoins.sdk.billing.managers.BrokerManager.getTransaction
 import com.appcoins.sdk.billing.managers.MMPEventsManager.sendSuccessfulPurchaseResultEvent
 import com.appcoins.sdk.billing.managers.ProductV2Manager
+import com.appcoins.sdk.billing.sharedpreferences.BackendRequestsSharedPreferences
+import com.appcoins.sdk.billing.usecases.RetryFailedRequests
 import com.appcoins.sdk.billing.usecases.UseCase
+import com.appcoins.sdk.core.logger.Logger.logError
 
 object SendSuccessfulPurchaseResponseEvent : UseCase() {
+
+    private val backendRequestsSharedPreferences: BackendRequestsSharedPreferences by lazy {
+        BackendRequestsSharedPreferences(WalletUtils.context)
+    }
+
     operator fun invoke(purchase: Purchase) {
         super.invokeUseCase()
         Thread {
-            val purchaseToken = purchase.token ?: return@Thread
-            val inappPurchaseResponse = ProductV2Manager.getInappPurchase(purchaseToken)
+            try {
+                val purchaseToken = purchase.token ?: throw NullPointerException("Purchase Token is missing.")
+                val inappPurchaseResponse = ProductV2Manager.getInappPurchase(purchaseToken)
 
-            val orderId = inappPurchaseResponse?.order?.reference ?: return@Thread
-            val transactionResponse = getTransaction(orderId)
+                val orderId =
+                    inappPurchaseResponse?.order?.reference ?: throw NullPointerException("OrderID is missing.")
+                val transactionResponse = getTransaction(orderId)
 
-            val price = transactionResponse?.price?.appc ?: return@Thread
+                val price = transactionResponse?.price?.appc ?: handleMissingPrice()
 
-            sendSuccessfulPurchaseResultEvent(purchase, orderId, price)
+                sendSuccessfulPurchaseResultEvent(purchase, orderId, price)
+            } catch (ex: NullPointerException) {
+                logError("There was an error creating the Successful Purchase event for MMP.", ex)
+            }
+            RetryFailedRequests(backendRequestsSharedPreferences)
         }.start()
+    }
+
+    private fun handleMissingPrice(): String {
+        logError("There was an error obtaining the Price. Using 0")
+        return "0"
     }
 }

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/usecases/mmp/SendSuccessfulPurchaseResponseEvent.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/usecases/mmp/SendSuccessfulPurchaseResponseEvent.kt
@@ -1,20 +1,14 @@
 package com.appcoins.sdk.billing.usecases.mmp
 
 import com.appcoins.sdk.billing.Purchase
-import com.appcoins.sdk.billing.helpers.WalletUtils
 import com.appcoins.sdk.billing.managers.BrokerManager.getTransaction
 import com.appcoins.sdk.billing.managers.MMPEventsManager.sendSuccessfulPurchaseResultEvent
 import com.appcoins.sdk.billing.managers.ProductV2Manager
-import com.appcoins.sdk.billing.sharedpreferences.BackendRequestsSharedPreferences
 import com.appcoins.sdk.billing.usecases.RetryFailedRequests
 import com.appcoins.sdk.billing.usecases.UseCase
 import com.appcoins.sdk.core.logger.Logger.logError
 
 object SendSuccessfulPurchaseResponseEvent : UseCase() {
-
-    private val backendRequestsSharedPreferences: BackendRequestsSharedPreferences by lazy {
-        BackendRequestsSharedPreferences(WalletUtils.context)
-    }
 
     operator fun invoke(purchase: Purchase) {
         super.invokeUseCase()
@@ -33,7 +27,7 @@ object SendSuccessfulPurchaseResponseEvent : UseCase() {
             } catch (ex: NullPointerException) {
                 logError("There was an error creating the Successful Purchase event for MMP.", ex)
             }
-            RetryFailedRequests(backendRequestsSharedPreferences)
+            RetryFailedRequests()
         }.start()
     }
 


### PR DESCRIPTION
**What does this PR do?**

It adds a retry mechanism for the MMP Purchase event, which will store the failed requests.
The failed requests, will be made again after of each start connection and at the end of each purchase to ensure there isn't a big gap without Purchase events received.

**What are the relevant tickets?**

Tickets related to this
pull-request: [APT-4430](https://aptoide.atlassian.net/browse/APT-4430)

**Questions:**

Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass