### PR TITLE
Implement Deeplinks with priority for StoreLink-Mapper request 

### DIFF
--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/managers/StoreDeepLinkManager.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/managers/StoreDeepLinkManager.kt
@@ -3,6 +3,7 @@ package com.appcoins.sdk.billing.managers
 import android.content.Context
 import com.appcoins.billing.sdk.BuildConfig
 import com.appcoins.sdk.billing.helpers.WalletUtils
+import com.appcoins.sdk.billing.mappers.StoreLinkResponse
 import com.appcoins.sdk.billing.repositories.StoreDeepLinkRepository
 import com.appcoins.sdk.billing.service.BdsService
 import com.appcoins.sdk.billing.usecases.GetOemIdForPackage
@@ -14,7 +15,7 @@ class StoreDeepLinkManager(private val context: Context) {
     private val storeDeepLinkRepository =
         StoreDeepLinkRepository(BdsService(BuildConfig.STORE_LINK_BASE_HOST, TIMEOUT_3_SECS))
 
-    fun getStoreDeepLink(): String? {
+    fun getStoreDeepLink(): StoreLinkResponse? {
         logInfo("Getting Store Deeplink value.")
         val oemid = GetOemIdForPackage(WalletUtils.context.packageName, WalletUtils.context)
         val installerAppPackage = GetInstallerAppPackage(context)

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/mappers/StoreLinkResponseMapper.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/mappers/StoreLinkResponseMapper.kt
@@ -29,7 +29,6 @@ class StoreLinkResponseMapper {
                 for (i in 0 until storeLinkMethodJsonArray.length()) {
                     val storeLinkMethodJSONObject = storeLinkMethodJsonArray.optJSONObject(i)
 
-
                     val deeplink = storeLinkMethodJSONObject.optString("deeplink")
                     val priority = storeLinkMethodJSONObject.optInt("priority", -1)
 
@@ -41,7 +40,8 @@ class StoreLinkResponseMapper {
             logError("There was a an error mapping the response.", ex)
         }
         return StoreLinkResponse(
-            response.responseCode, storeLinkMethods.filter { it.priority >= 0 }.toCollection(arrayListOf())
+            response.responseCode,
+            storeLinkMethods.filter { it.priority >= 0 }.toCollection(arrayListOf())
         )
     }
 }

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/mappers/StoreLinkResponseMapper.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/mappers/StoreLinkResponseMapper.kt
@@ -22,17 +22,36 @@ class StoreLinkResponseMapper {
             return StoreLinkResponse(response.responseCode)
         }
 
-        val deeplink = runCatching {
-            JSONObject(response.response).optString("deeplink").takeIf { it.isNotEmpty() }
-        }.getOrElse {
-            logError("There was a an error mapping the response.", Exception(it))
-            null
+        val storeLinkMethods = arrayListOf<StoreLinkMethod>()
+        try {
+            val responseJsonObject = JSONObject(response.response)
+            responseJsonObject.optJSONArray("store_link_methods")?.let { storeLinkMethodJsonArray ->
+                for (i in 0 until storeLinkMethodJsonArray.length()) {
+                    val storeLinkMethodJSONObject = storeLinkMethodJsonArray.optJSONObject(i)
+
+
+                    val deeplink = storeLinkMethodJSONObject.optString("deeplink")
+                    val priority = storeLinkMethodJSONObject.optInt("priority", -1)
+
+                    storeLinkMethods.add(StoreLinkMethod(deeplink, priority))
+                }
+                storeLinkMethods.sortBy { it.priority }
+            }
+        } catch (ex: Exception) {
+            logError("There was a an error mapping the response.", ex)
         }
-        return StoreLinkResponse(response.responseCode, deeplink)
+        return StoreLinkResponse(
+            response.responseCode, storeLinkMethods.filter { it.priority >= 0 }.toCollection(arrayListOf())
+        )
     }
 }
 
 data class StoreLinkResponse(
     val responseCode: Int?,
-    val deeplink: String? = null
+    val storeLinkMethods: ArrayList<StoreLinkMethod> = arrayListOf()
+)
+
+data class StoreLinkMethod(
+    val deeplink: String,
+    val priority: Int,
 )

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/repositories/StoreDeepLinkRepository.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/repositories/StoreDeepLinkRepository.kt
@@ -1,5 +1,6 @@
 package com.appcoins.sdk.billing.repositories
 
+import com.appcoins.sdk.billing.mappers.StoreLinkResponse
 import com.appcoins.sdk.billing.mappers.StoreLinkResponseMapper
 import com.appcoins.sdk.billing.service.BdsService
 import com.appcoins.sdk.billing.service.ServiceResponseListener
@@ -14,21 +15,22 @@ class StoreDeepLinkRepository(private val bdsService: BdsService) {
         packageName: String,
         appInstallerPackageName: String?,
         oemid: String?,
-    ): String? {
+    ): StoreLinkResponse? {
         val countDownLatch = CountDownLatch(1)
-        var storeDeepLink: String? = null
+        var storeDeepLink: StoreLinkResponse? = null
 
         val queries: MutableMap<String, String> = LinkedHashMap()
+        queries["version"] = "2"
         appInstallerPackageName?.let { queries["store-package"] = it }
         oemid?.let { queries["oemid"] = it }
 
         val serviceResponseListener =
             ServiceResponseListener { requestResponse ->
                 requestResponse?.let {
-                    val webPaymentUrlResponse = StoreLinkResponseMapper().map(requestResponse)
-                    webPaymentUrlResponse.responseCode?.let { responseCode ->
+                    val storeLinkResponse = StoreLinkResponseMapper().map(requestResponse)
+                    storeLinkResponse.responseCode?.let { responseCode ->
                         if (ServiceUtils.isSuccess(responseCode)) {
-                            storeDeepLink = webPaymentUrlResponse.deeplink
+                            storeDeepLink = storeLinkResponse
                         }
                     }
                 }

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/webpayment/WebAppcoinsBilling.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/webpayment/WebAppcoinsBilling.kt
@@ -211,7 +211,7 @@ class WebAppcoinsBilling private constructor() : AppcoinsBilling, Serializable {
         responseWs: Bundle
     ) {
         val sku = skusBundle.getStringArrayList(GET_SKU_DETAILS_ITEM_LIST)
-        val skuDetailsList = requestSkuDetails(sku, packageName)
+        val skuDetailsList = sku?.let { requestSkuDetails(sku, packageName) } ?: emptyList()
         val skuDetailsResult = SkuDetailsResultV2(skuDetailsList, 0)
         responseWs.putInt(RESPONSE_CODE, 0)
         val skuDetails = buildResponse(skuDetailsResult)
@@ -227,25 +227,20 @@ class WebAppcoinsBilling private constructor() : AppcoinsBilling, Serializable {
         return requestSingleSkuDetails(sku, packageName, type)
     }
 
-    private fun requestSkuDetails(
-        sku: List<String>?,
-        packageName: String
-    ): ArrayList<SkuDetailsV2> {
-        val skuSendList: ArrayList<String> = ArrayList()
+    private fun requestSkuDetails(sku: List<String>, packageName: String): ArrayList<SkuDetailsV2> {
         val skuDetailsList = ArrayList<SkuDetailsV2>()
+        val skuSendList: ArrayList<String> = ArrayList()
 
-        if (sku != null) {
-            for (i in 1..sku.size) {
-                skuSendList.add(sku[i - 1])
-                if (i % MAX_SKUS_SEND_WS == 0 || i == sku.size) {
-                    val skuDetailsResponse = ProductV2Manager.getSkuDetails(
-                        packageName,
-                        skuSendList,
-                        getPaymentFlowFromPayflowMethod(WalletUtils.paymentFlowMethods.toMutableList())
-                    )
-                    skuDetailsList.addAll(skuDetailsResponse?.items ?: emptyList())
-                    skuSendList.clear()
-                }
+        for (i in 1..sku.size) {
+            skuSendList.add(sku[i - 1])
+            if (i % MAX_SKUS_SEND_WS == 0 || i == sku.size) {
+                val skuDetailsResponse = ProductV2Manager.getSkuDetails(
+                    packageName,
+                    skuSendList,
+                    getPaymentFlowFromPayflowMethod(WalletUtils.paymentFlowMethods.toMutableList())
+                )
+                skuDetailsList.addAll(skuDetailsResponse?.items ?: emptyList())
+                skuSendList.clear()
             }
         }
         return skuDetailsList


### PR DESCRIPTION
**What does this PR do?**

This PR adds a logic to use a priority queue for the StoreLink-Mapper request.
The Deeplinks will be retrieved following a priority set on the Backend and the SDK will redirect the User to those Deeplinks depending on the availability.

**What are the relevant tickets?**

Tickets related to this
pull-request: [APT-4497](https://aptoide.atlassian.net/browse/APT-4497)

**Questions:**

Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass