### PR TITLE
Add Network speed to Analytics Failure events

### DIFF
--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/analytics/AnalyticsContent.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/analytics/AnalyticsContent.kt
@@ -28,6 +28,7 @@ object AnalyticsLabels {
     const val PAYMENT_STATUS_MESSAGE = "status_message"
     const val FAILURE_TYPE = "failure_type"
     const val FAILURE_MESSAGE = "failure_message"
+    const val NETWORK_SPEED = "network_speed"
 }
 
 object SdkAnalyticsEvents {

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/analytics/SdkAnalytics.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/analytics/SdkAnalytics.kt
@@ -2,6 +2,8 @@ package com.appcoins.sdk.billing.analytics
 
 import com.appcoins.sdk.billing.analytics.manager.AnalyticsManager
 import com.appcoins.sdk.billing.analytics.manager.AnalyticsManager.Action
+import com.appcoins.sdk.billing.helpers.WalletUtils
+import com.appcoins.sdk.core.network.NetworkTraffic
 
 @Suppress("complexity:TooManyFunctions")
 class SdkAnalytics(private val analyticsManager: AnalyticsManager) {
@@ -269,6 +271,7 @@ class SdkAnalytics(private val analyticsManager: AnalyticsManager) {
         val eventData: MutableMap<String, Any> = HashMap()
         eventData[AnalyticsLabels.FAILURE_TYPE] = failureType
         failureMessage?.let { eventData[AnalyticsLabels.FAILURE_MESSAGE] = it }
+        eventData[AnalyticsLabels.NETWORK_SPEED] = NetworkTraffic().getAverageSpeed(WalletUtils.context) ?: "null"
 
         logEvent(
             eventData,

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/managers/AttributionManager.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/managers/AttributionManager.kt
@@ -16,8 +16,8 @@ import com.appcoins.sdk.billing.utils.AppcoinsBillingConstants.TIMEOUT_30_SECS
 import com.appcoins.sdk.billing.utils.ServiceUtils.isSuccess
 import com.appcoins.sdk.core.logger.Logger.logError
 import com.appcoins.sdk.core.logger.Logger.logInfo
-import com.appcoins.sdk.core.retrymechanism.exceptions.IncompleteCircularFunctionExecutionException
-import com.appcoins.sdk.core.retrymechanism.retryUntilSuccess
+import com.appcoins.sdk.core.network.retrymechanism.exceptions.IncompleteCircularFunctionExecutionException
+import com.appcoins.sdk.core.network.retrymechanism.retryUntilSuccess
 
 object AttributionManager {
     private val packageName by lazy { WalletUtils.context.packageName }

--- a/android-appcoins-billing/src/test/java/com/appcoins/sdk/billing/analytics/SdkAnalyticsTest.kt
+++ b/android-appcoins-billing/src/test/java/com/appcoins/sdk/billing/analytics/SdkAnalyticsTest.kt
@@ -1,10 +1,13 @@
 package com.appcoins.sdk.billing.analytics
 
+import android.content.Context
 import com.appcoins.sdk.billing.analytics.manager.AnalyticsManager
 import com.appcoins.sdk.billing.analytics.manager.AnalyticsManager.Action
+import com.appcoins.sdk.billing.helpers.WalletUtils
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.verify
 import org.junit.Before
@@ -19,10 +22,13 @@ class SdkAnalyticsTest {
     private lateinit var sdkAnalytics: SdkAnalytics
 
     private val mockkAnalyticsManager = mockk<AnalyticsManager>()
+    private val mockkContext = mockk<Context>()
 
     @Before
     fun setup() {
         sdkAnalytics = SdkAnalytics(mockkAnalyticsManager)
+        mockkStatic(WalletUtils::class)
+        WalletUtils.context = mockkContext
     }
 
     @Test

--- a/appcoins-core/src/main/AndroidManifest.xml
+++ b/appcoins-core/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.appcoins.sdk.core">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
 </manifest>

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/network/NetworkTraffic.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/network/NetworkTraffic.kt
@@ -6,7 +6,6 @@ import android.os.Build
 import com.appcoins.sdk.core.logger.Logger.logInfo
 import com.appcoins.sdk.core.logger.Logger.logWarning
 
-
 class NetworkTraffic {
 
     fun getAverageSpeed(context: Context): String? {
@@ -17,7 +16,7 @@ class NetworkTraffic {
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> {
                     val networkCapabilities =
                         connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
-                    val downstreamSpeedInMbps = networkCapabilities!!.linkDownstreamBandwidthKbps / 1000
+                    val downstreamSpeedInMbps = networkCapabilities!!.linkDownstreamBandwidthKbps / MBPS_DIVIDER
 
                     logInfo("Network speed obtained: $downstreamSpeedInMbps")
                     downstreamSpeedInMbps.toString()
@@ -43,5 +42,9 @@ class NetworkTraffic {
             logWarning("There was an error obtaining network speed. ${ex.message}")
             return null
         }
+    }
+
+    private companion object {
+        const val MBPS_DIVIDER = 1000
     }
 }

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/network/NetworkTraffic.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/network/NetworkTraffic.kt
@@ -1,0 +1,47 @@
+package com.appcoins.sdk.core.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.os.Build
+import com.appcoins.sdk.core.logger.Logger.logInfo
+import com.appcoins.sdk.core.logger.Logger.logWarning
+
+
+class NetworkTraffic {
+
+    fun getAverageSpeed(context: Context): String? {
+        logInfo("Obtaining Network speed information.")
+        try {
+            val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            return when {
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> {
+                    val networkCapabilities =
+                        connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+                    val downstreamSpeedInMbps = networkCapabilities!!.linkDownstreamBandwidthKbps / 1000
+
+                    logInfo("Network speed obtained: $downstreamSpeedInMbps")
+                    downstreamSpeedInMbps.toString()
+                }
+
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP -> {
+                    val activeNetwork = connectivityManager.activeNetworkInfo
+                    if (activeNetwork != null && activeNetwork.isConnected) {
+                        logWarning("Device network information is not available.")
+                        "-1"
+                    } else {
+                        logWarning("Network is not available.")
+                        "0"
+                    }
+                }
+
+                else -> {
+                    logWarning("Device not compatible for Network speed evaluation.")
+                    null
+                }
+            }
+        } catch (ex: Exception) {
+            logWarning("There was an error obtaining network speed. ${ex.message}")
+            return null
+        }
+    }
+}

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/network/retrymechanism/RetryHandler.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/network/retrymechanism/RetryHandler.kt
@@ -1,9 +1,9 @@
-package com.appcoins.sdk.core.retrymechanism
+package com.appcoins.sdk.core.network.retrymechanism
 
 import com.appcoins.sdk.core.logger.Logger.logError
 import com.appcoins.sdk.core.logger.Logger.logInfo
-import com.appcoins.sdk.core.retrymechanism.exceptions.IncompleteCircularFunctionExecutionException
-import com.appcoins.sdk.core.retrymechanism.exceptions.MaxAttemptsReachedException
+import com.appcoins.sdk.core.network.retrymechanism.exceptions.IncompleteCircularFunctionExecutionException
+import com.appcoins.sdk.core.network.retrymechanism.exceptions.MaxAttemptsReachedException
 
 fun <T> retryUntilSuccess(
     retries: Int? = null,

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/network/retrymechanism/exceptions/IncompleteCircularFunctionExecutionException.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/network/retrymechanism/exceptions/IncompleteCircularFunctionExecutionException.kt
@@ -1,3 +1,3 @@
-package com.appcoins.sdk.core.retrymechanism.exceptions
+package com.appcoins.sdk.core.network.retrymechanism.exceptions
 
 class IncompleteCircularFunctionExecutionException(message: String) : Exception(message)

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/network/retrymechanism/exceptions/MaxAttemptsReachedException.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/network/retrymechanism/exceptions/MaxAttemptsReachedException.kt
@@ -1,0 +1,3 @@
+package com.appcoins.sdk.core.network.retrymechanism.exceptions
+
+class MaxAttemptsReachedException : Exception()

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/retrymechanism/exceptions/MaxAttemptsReachedException.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/retrymechanism/exceptions/MaxAttemptsReachedException.kt
@@ -1,3 +1,0 @@
-package com.appcoins.sdk.core.retrymechanism.exceptions
-
-class MaxAttemptsReachedException : Exception()

--- a/appcoins-core/src/test/java/com/appcoins/sdk/core/network/NetworkTrafficTest.kt
+++ b/appcoins-core/src/test/java/com/appcoins/sdk/core/network/NetworkTrafficTest.kt
@@ -1,0 +1,117 @@
+package com.appcoins.sdk.core.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkInfo
+import android.os.Build
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [23])
+class NetworkTrafficTest {
+
+    private val networkTraffic: NetworkTraffic = NetworkTraffic()
+
+    @Test
+    fun `should return null if an Exception was thrown`() {
+        val mockkContext = mockk<Context>()
+
+        every { mockkContext.getSystemService(Context.CONNECTIVITY_SERVICE) } returns null
+
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.M)
+
+        val result = networkTraffic.getAverageSpeed(mockkContext)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `should return null if Build VERSION is not above KITKAT_WATCH`() {
+        val mockkContext = mockk<Context>()
+        every { mockkContext.getSystemService(Context.CONNECTIVITY_SERVICE) } returns null
+
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.KITKAT_WATCH)
+
+        val result = networkTraffic.getAverageSpeed(mockkContext)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `should return 0 if Build VERSION is LOLLIPOP and no internet connection available`() {
+        val mockkContext = mockk<Context>()
+        val mockkConnectivityManager = mockk<ConnectivityManager>()
+        val mockkActiveNetworkInfo = mockk<NetworkInfo>()
+
+        every { mockkContext.getSystemService(Context.CONNECTIVITY_SERVICE) } returns mockkConnectivityManager
+        every { mockkConnectivityManager.activeNetworkInfo } returns mockkActiveNetworkInfo
+        every { mockkActiveNetworkInfo.isConnected } returns false
+
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.LOLLIPOP)
+
+        val result = networkTraffic.getAverageSpeed(mockkContext)
+
+        assertEquals(result, "0")
+    }
+
+    @Test
+    fun `should return 0 if Build VERSION is LOLLIPOP and no active networks info found`() {
+        val mockkContext = mockk<Context>()
+        val mockkConnectivityManager = mockk<ConnectivityManager>()
+
+        every { mockkContext.getSystemService(Context.CONNECTIVITY_SERVICE) } returns mockkConnectivityManager
+        every { mockkConnectivityManager.activeNetworkInfo } returns null
+
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.LOLLIPOP)
+
+        val result = networkTraffic.getAverageSpeed(mockkContext)
+
+        assertEquals(result, "0")
+    }
+
+    @Test
+    fun `should return -1 if Build VERSION is LOLLIPOP and internet connection is available`() {
+        val mockkContext = mockk<Context>()
+        val mockkConnectivityManager = mockk<ConnectivityManager>()
+        val mockkActiveNetworkInfo = mockk<NetworkInfo>()
+
+        every { mockkContext.getSystemService(Context.CONNECTIVITY_SERVICE) } returns mockkConnectivityManager
+        every { mockkConnectivityManager.activeNetworkInfo } returns mockkActiveNetworkInfo
+        every { mockkActiveNetworkInfo.isConnected } returns true
+
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.LOLLIPOP)
+
+        val result = networkTraffic.getAverageSpeed(mockkContext)
+
+        assertEquals(result, "-1")
+    }
+
+    @Test
+    fun `should return correct network speed if Build VERSION is M`() {
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", Build.VERSION_CODES.M)
+
+        val mockkContext = mockk<Context>()
+        val mockkConnectivityManager = mockk<ConnectivityManager>()
+        val mockkActiveNetwork = mockk<Network>()
+        val mockkNetworkCapabilities = mockk<NetworkCapabilities>()
+
+        every { mockkContext.getSystemService(Context.CONNECTIVITY_SERVICE) } returns mockkConnectivityManager
+        every { mockkConnectivityManager.activeNetwork } returns mockkActiveNetwork
+        every { mockkConnectivityManager.getNetworkCapabilities(mockkActiveNetwork) } returns mockkNetworkCapabilities
+        every { mockkNetworkCapabilities.linkDownstreamBandwidthKbps } returns 1000
+
+        val result = networkTraffic.getAverageSpeed(mockkContext)
+
+        assertEquals(result, "1")
+    }
+}

--- a/appcoins-core/src/test/java/com/appcoins/sdk/core/network/retrymechanism/RetryHandlerTest.kt
+++ b/appcoins-core/src/test/java/com/appcoins/sdk/core/network/retrymechanism/RetryHandlerTest.kt
@@ -1,7 +1,6 @@
-package com.appcoins.sdk.core.retrymechanism
+package com.appcoins.sdk.core.network.retrymechanism
 
 import com.appcoins.sdk.core.logger.Logger
-import com.appcoins.sdk.core.network.retrymechanism.retryUntilSuccess
 import com.appcoins.sdk.core.network.retrymechanism.exceptions.IncompleteCircularFunctionExecutionException
 import com.appcoins.sdk.core.network.retrymechanism.exceptions.MaxAttemptsReachedException
 import io.mockk.mockkStatic

--- a/appcoins-core/src/test/java/com/appcoins/sdk/core/retrymechanism/RetryHandlerTest.kt
+++ b/appcoins-core/src/test/java/com/appcoins/sdk/core/retrymechanism/RetryHandlerTest.kt
@@ -1,8 +1,9 @@
 package com.appcoins.sdk.core.retrymechanism
 
 import com.appcoins.sdk.core.logger.Logger
-import com.appcoins.sdk.core.retrymechanism.exceptions.IncompleteCircularFunctionExecutionException
-import com.appcoins.sdk.core.retrymechanism.exceptions.MaxAttemptsReachedException
+import com.appcoins.sdk.core.network.retrymechanism.retryUntilSuccess
+import com.appcoins.sdk.core.network.retrymechanism.exceptions.IncompleteCircularFunctionExecutionException
+import com.appcoins.sdk.core.network.retrymechanism.exceptions.MaxAttemptsReachedException
 import io.mockk.mockkStatic
 import io.mockk.verify
 import org.junit.Before


### PR DESCRIPTION
**What does this PR do?**

This PR adds the Network speed to the Analytics failure events.
This is available to Android 23 minimum level.

**What are the relevant tickets?**

Tickets related to this
pull-request: [APT-4547](https://aptoide.atlassian.net/browse/APT-4547)

**Questions:**

Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass