### PR TITLE
Add default LOG Verbosity and Analytics Cache mechanism

### DIFF
--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/payflow/PayflowManager.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/payflow/PayflowManager.kt
@@ -26,15 +26,14 @@ object PayflowManager {
                         val sortedMethods = payflowMethodResponse.paymentFlowList
                         sortedMethods?.sortBy { it.priority }
                         PayflowPriorityStream.getInstance().emit(sortedMethods)
-                        payflowMethodResponse.analyticsFlowSeverityLevels
-                            ?.takeIf { it.isNotEmpty() }
-                            ?.let {
-                                SdkAnalyticsUtils.analyticsFlowSeverityLevels = it
-                            }
+                        payflowMethodResponse.analyticsFlowSeverityLevels?.let {
+                            SdkAnalyticsUtils.analyticsFlowSeverityLevels = it
+                        }
                     } else {
                         PayflowPriorityStream.getInstance().emit(arrayListOf())
                         SdkAnalyticsUtils.analyticsFlowSeverityLevels = null
                     }
+                    SdkAnalyticsUtils.isAnalyticsSetupFromPayflowFinalized = true
                 }
             }
         }

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/payflow/models/PaymentFlowMethod.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/payflow/models/PaymentFlowMethod.kt
@@ -62,7 +62,8 @@ sealed class PaymentFlowMethod(
                 "priority: $priority, " +
                 "version: $version, " +
                 "paymentFlow: $paymentFlow, " +
-                "webViewDetails: $webViewDetails]"
+                "webViewDetails: $webViewDetails, " +
+                "availableFeatures: $availableFeatures]"
 
         override fun equals(other: Any?): Boolean {
             if (other != null) {
@@ -72,7 +73,8 @@ sealed class PaymentFlowMethod(
                         other.priority == priority &&
                         other.paymentFlow == paymentFlow &&
                         other.version == version &&
-                        other.webViewDetails == webViewDetails
+                        other.webViewDetails == webViewDetails &&
+                        other.availableFeatures == availableFeatures
                 }
             }
             return false
@@ -103,13 +105,15 @@ sealed class PaymentFlowMethod(
     }
 
     override fun toString(): String =
-        "${this.javaClass.name}: [name: $name, priority: $priority]"
+        "${this.javaClass.name}: [name: $name, priority: $priority, availableFeatures: $availableFeatures]"
 
     override fun equals(other: Any?): Boolean {
         if (other != null) {
             if (other::class.java == this::class.java) {
                 other as PaymentFlowMethod
-                return other.name == name && other.priority == priority
+                return other.name == name &&
+                    other.priority == priority &&
+                    other.availableFeatures == availableFeatures
             }
         }
         return false

--- a/android-appcoins-billing/src/test/java/com/appcoins/sdk/billing/helpers/WalletUtilsTest.kt
+++ b/android-appcoins-billing/src/test/java/com/appcoins/sdk/billing/helpers/WalletUtilsTest.kt
@@ -18,6 +18,8 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkAll
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.After
 import org.junit.Before
@@ -122,6 +124,7 @@ class WalletUtilsTest {
     fun `startIndicative should return OK when generates correctly Bundle`() {
         mockkStatic(Indicative::class)
         mockkObject(ApiKeysManager)
+        mockkObject(SdkAnalyticsUtils)
 
         val mockkIndicative = mockk<Indicative>()
         val mockkSharedPreferences = mockk<SharedPreferences>()
@@ -138,6 +141,9 @@ class WalletUtilsTest {
         shadowOf(Looper.getMainLooper()).runToNextTask()
 
         verify(exactly = 1) { SdkAnalyticsUtils.sdkAnalytics.sendStartConnectionEvent() }
+        unmockkObject(SdkAnalyticsUtils)
+        unmockkObject(ApiKeysManager)
+        unmockkStatic(Indicative::class)
     }
 
     private companion object {

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/SdkAnalyticsUtils.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/SdkAnalyticsUtils.kt
@@ -6,9 +6,14 @@ import com.appcoins.sdk.core.analytics.events.SdkPurchaseFlowEvents.PURCHASE_FLO
 import com.appcoins.sdk.core.analytics.events.SdkWalletPaymentFlowEvents.WALLET_PAYMENT_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkWebPaymentFlowEvents.WEB_PAYMENT_FLOW
 import com.appcoins.sdk.core.analytics.severity.AnalyticsFlowSeverityLevel
+import com.appcoins.sdk.core.logger.Logger.logInfo
 
 object SdkAnalyticsUtils {
     var analyticsFlowSeverityLevels: List<AnalyticsFlowSeverityLevel>? = null
+        set(value) {
+            field = value
+            logInfo(value.toString())
+        }
     val defaultAnalyticsFlowSeverityLevels =
         listOf(
             AnalyticsFlowSeverityLevel(flow = CONSUME_PURCHASE_FLOW, 1),

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/SdkAnalyticsUtils.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/SdkAnalyticsUtils.kt
@@ -1,9 +1,29 @@
 package com.appcoins.sdk.core.analytics
 
+import com.appcoins.sdk.core.analytics.events.SdkConsumePurchaseEvents.CONSUME_PURCHASE_FLOW
+import com.appcoins.sdk.core.analytics.events.SdkInstallWalletDialogEvents.INSTALL_WALLET_DIALOG_FLOW
+import com.appcoins.sdk.core.analytics.events.SdkPurchaseFlowEvents.PURCHASE_FLOW
+import com.appcoins.sdk.core.analytics.events.SdkWalletPaymentFlowEvents.WALLET_PAYMENT_FLOW
+import com.appcoins.sdk.core.analytics.events.SdkWebPaymentFlowEvents.WEB_PAYMENT_FLOW
 import com.appcoins.sdk.core.analytics.severity.AnalyticsFlowSeverityLevel
 
 object SdkAnalyticsUtils {
     var analyticsFlowSeverityLevels: List<AnalyticsFlowSeverityLevel>? = null
+    val defaultAnalyticsFlowSeverityLevels =
+        listOf(
+            AnalyticsFlowSeverityLevel(flow = CONSUME_PURCHASE_FLOW, 1),
+            AnalyticsFlowSeverityLevel(flow = PURCHASE_FLOW, 1),
+            AnalyticsFlowSeverityLevel(flow = WALLET_PAYMENT_FLOW, 1),
+            AnalyticsFlowSeverityLevel(flow = WEB_PAYMENT_FLOW, 2),
+            AnalyticsFlowSeverityLevel(flow = INSTALL_WALLET_DIALOG_FLOW, 1),
+        )
+    var isAnalyticsSetupFromPayflowFinalized: Boolean = false
+        set(value) {
+            field = value
+            if (value) {
+                sdkAnalytics.sendEventsOnQueue()
+            }
+        }
     val sdkAnalytics: SdkAnalytics by lazy { SdkAnalytics(AnalyticsManagerProvider.provideAnalyticsManager()) }
     var isIndicativeEventLoggerInitialized = false
 }

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkAppUpdateAvailableEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkAppUpdateAvailableEvents.kt
@@ -46,7 +46,7 @@ object SdkAppUpdateAvailableEvents {
     const val SDK_APP_UPDATE_AVAILABLE_FAILURE_TO_OBTAIN_RESULT =
         "sdk_app_update_available_failure_to_obtain_result"
 
-    private const val APP_UPDATE_AVAILABLE_FLOW = "app_update_available"
+    const val APP_UPDATE_AVAILABLE_FLOW = "app_update_available"
 }
 
 object SdkAppUpdateAvailableLabels {

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkBackendRequestEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkBackendRequestEvents.kt
@@ -45,7 +45,7 @@ object SdkBackendRequestEvents {
     const val SDK_CALL_BACKEND_MAPPING_FAILURE = "sdk_call_backend_mapping_failure"
     const val SDK_CALL_BACKEND_ERROR = "sdk_call_backend_error"
 
-    private const val BACKEND_REQUEST_FLOW = "backend_request"
+    const val BACKEND_REQUEST_FLOW = "backend_request"
 }
 
 object SdkBackendRequestLabels {

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkConsumePurchaseEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkConsumePurchaseEvents.kt
@@ -25,7 +25,7 @@ object SdkConsumePurchaseEvents {
     const val SDK_CONSUME_PURCHASE_REQUEST = "sdk_consume_purchase_request"
     const val SDK_CONSUME_PURCHASE_RESULT = "sdk_consume_purchase_result"
 
-    private const val CONSUME_PURCHASE_FLOW = "consume_purchase"
+    const val CONSUME_PURCHASE_FLOW = "consume_purchase"
 }
 
 object SdkConsumePurchaseLabels {

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkGeneralFailureEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkGeneralFailureEvents.kt
@@ -35,7 +35,7 @@ object SdkGeneralFailureEvents {
     const val SDK_PURCHASE_SIGNATURE_VERIFICATION_FAILURE = "sdk_purchase_signature_verification_failure"
     const val SDK_UNEXPECTED_FAILURE = "sdk_unexpected_failure"
 
-    private const val GENERAL_FAILURE_FLOW = "general_failure"
+    const val GENERAL_FAILURE_FLOW = "general_failure"
 }
 
 object SdkGeneralFailureLabels {

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkGetReferralDeeplinkEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkGetReferralDeeplinkEvents.kt
@@ -35,7 +35,7 @@ object SdkGetReferralDeeplinkEvents {
     const val SDK_GET_REFERRAL_DEEPLINK_RESULT = "sdk_referral_deeplink_result"
     const val SDK_GET_REFERRAL_DEEPLINK_MAIN_THREAD_FAILURE = "sdk_referral_deeplink_main_thread_failure"
 
-    private const val GET_REFERRAL_DEEPLINK_FLOW = "get_referral_deeplink"
+    const val GET_REFERRAL_DEEPLINK_FLOW = "get_referral_deeplink"
 }
 
 object SdkGetReferralDeeplinkLabels {

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkInitializationEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkInitializationEvents.kt
@@ -114,7 +114,7 @@ object SdkInitializationEvents {
     const val SDK_SERVICE_CONNECTION_FAILED = "sdk_service_connection_failed"
     const val SDK_APP_INSTALLATION_TRIGGER = "sdk_app_installation_trigger"
 
-    private const val SDK_INITIALIZATION_FLOW = "initialization"
+    const val SDK_INITIALIZATION_FLOW = "initialization"
 }
 
 object SdkInitializationLabels {

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkInstallWalletDialogEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkInstallWalletDialogEvents.kt
@@ -55,7 +55,7 @@ object SdkInstallWalletDialogEvents {
     const val SDK_INSTALL_WALLET_DIALOG_DOWNLOAD_WALLET_FALLBACK = "sdk_install_wallet_dialog_download_wallet_fallback"
     const val SDK_INSTALL_WALLET_DIALOG_SUCCESS = "sdk_install_wallet_dialog_success"
 
-    private const val INSTALL_WALLET_DIALOG_FLOW = "install_wallet_dialog"
+    const val INSTALL_WALLET_DIALOG_FLOW = "install_wallet_dialog"
 }
 
 object SdkInstallWalletDialogLabels {

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkIsFeatureSupportedEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkIsFeatureSupportedEvents.kt
@@ -25,7 +25,7 @@ object SdkIsFeatureSupportedEvents {
     const val SDK_IS_FEATURE_SUPPORTED_REQUEST = "sdk_is_feature_supported_request"
     const val SDK_IS_FEATURE_SUPPORTED_RESULT = "sdk_is_feature_supported_result"
 
-    private const val IS_FEATURE_SUPPORTED_FLOW = "is_feature_supported"
+    const val IS_FEATURE_SUPPORTED_FLOW = "is_feature_supported"
 }
 
 object SdkIsFeatureSupportedLabels {

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkLaunchAppUpdateDialogEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkLaunchAppUpdateDialogEvents.kt
@@ -25,7 +25,7 @@ object SdkLaunchAppUpdateDialogEvents {
     const val SDK_LAUNCH_APP_UPDATE_DIALOG_REQUEST = "sdk_launch_app_update_dialog_request"
     const val SDK_LAUNCH_APP_UPDATE_DIALOG_ACTION = "sdk_launch_app_update_dialog_action"
 
-    private const val LAUNCH_APP_UPDATE_DIALOG_FLOW = "launch_app_update_dialog"
+    const val LAUNCH_APP_UPDATE_DIALOG_FLOW = "launch_app_update_dialog"
 }
 
 object SdkLaunchAppUpdateDialogLabels {

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkLaunchAppUpdateEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkLaunchAppUpdateEvents.kt
@@ -25,7 +25,7 @@ object SdkLaunchAppUpdateEvents {
     const val SDK_LAUNCH_APP_UPDATE_RESULT = "sdk_launch_app_update_result"
     const val SDK_LAUNCH_APP_UPDATE_DEEPLINK_FAILURE = "sdk_launch_app_update_deeplink_failure"
 
-    private const val LAUNCH_APP_UPDATE_FLOW = "launch_app_update"
+    const val LAUNCH_APP_UPDATE_FLOW = "launch_app_update"
 }
 
 object SdkLaunchAppUpdateLabels {

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkLaunchAppUpdateStoreEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkLaunchAppUpdateStoreEvents.kt
@@ -15,5 +15,5 @@ object SdkLaunchAppUpdateStoreEvents {
 
     const val SDK_LAUNCH_APP_UPDATE_STORE_REQUEST = "sdk_launch_app_update_store_request"
 
-    private const val LAUNCH_APP_UPDATE_STORE_FLOW = "launch_app_update_store"
+    const val LAUNCH_APP_UPDATE_STORE_FLOW = "launch_app_update_store"
 }

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkPurchaseFlowEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkPurchaseFlowEvents.kt
@@ -45,7 +45,7 @@ object SdkPurchaseFlowEvents {
     const val SDK_LAUNCH_PURCHASE_TYPE_NOT_SUPPORTED_FAILURE = "sdk_launch_purchase_type_not_supported_failure"
     const val SDK_LAUNCH_PURCHASE_MAIN_THREAD_FAILURE = "sdk_launch_purchase_main_thread_failure"
 
-    private const val PURCHASE_FLOW = "purchase_flow"
+    const val PURCHASE_FLOW = "purchase_flow"
 }
 
 object SdkPurchaseFlowLabels {
@@ -54,6 +54,8 @@ object SdkPurchaseFlowLabels {
     const val DEVELOPER_PAYLOAD = "developer_payload"
     const val ORDER_REFERENCE = "order_reference"
     const val ORIGIN = "origin"
+
+    const val FAILURE_MESSAGE = "failure_message"
 
     const val RESPONSE_CODE = "response_code"
     const val PURCHASE_TOKEN = "purchase_token"

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkQueryPurchasesEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkQueryPurchasesEvents.kt
@@ -34,7 +34,7 @@ object SdkQueryPurchasesEvents {
     const val SDK_QUERY_PURCHASES_TYPE_NOT_SUPPORTED_ERROR = "sdk_query_purchases_type_not_supported_error"
     const val SDK_QUERY_PURCHASES_RESULT = "sdk_query_purchases_result"
 
-    private const val SDK_QUERY_PURCHASES_FLOW = "query_purchases"
+    const val SDK_QUERY_PURCHASES_FLOW = "query_purchases"
 }
 
 object SdkQueryPurchasesLabels {

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkQuerySkuDetailsEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkQuerySkuDetailsEvents.kt
@@ -35,7 +35,7 @@ object SdkQuerySkuDetailsEvents {
     const val SDK_QUERY_SKU_DETAILS_RESULT = "sdk_query_sku_details_result"
     const val SDK_QUERY_SKU_DETAILS_FAILURE_PARSING_SKUS = "sdk_query_sku_details_failure_on_parsing_skus"
 
-    private const val QUERY_SKU_DETAILS_FLOW = "query_sku_details"
+    const val QUERY_SKU_DETAILS_FLOW = "query_sku_details"
 }
 
 object SdkQuerySkuDetailsLabels {

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkWalletPaymentFlowEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkWalletPaymentFlowEvents.kt
@@ -25,5 +25,5 @@ object SdkWalletPaymentFlowEvents {
     const val SDK_WALLET_PAYMENT_START = "sdk_wallet_payment_start"
     const val SDK_WALLET_PAYMENT_EMPTY_DATA = "sdk_wallet_payment_empty_data"
 
-    private const val WALLET_PAYMENT_FLOW = "wallet_payment_flow"
+    const val WALLET_PAYMENT_FLOW = "wallet_payment_flow"
 }

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkWebPaymentFlowEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkWebPaymentFlowEvents.kt
@@ -115,7 +115,7 @@ object SdkWebPaymentFlowEvents {
     const val SDK_WEB_PAYMENT_EXECUTE_EXTERNAL_DEEPLINK = "sdk_web_payment_execute_external_deeplink"
     const val SDK_WEB_PAYMENT_WALLET_PAYMENT_RESULT = "sdk_web_payment_wallet_payment_result"
 
-    private const val WEB_PAYMENT_FLOW = "web_payment_flow"
+    const val WEB_PAYMENT_FLOW = "web_payment_flow"
 }
 
 object SdkWebPaymentFlowLabels {

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/severity/SdkAnalyticsSeverityUtils.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/severity/SdkAnalyticsSeverityUtils.kt
@@ -10,7 +10,7 @@ class SdkAnalyticsSeverityUtils {
             (
                 SdkAnalyticsUtils.analyticsFlowSeverityLevels
                     ?: SdkAnalyticsUtils.defaultAnalyticsFlowSeverityLevels
-                ).firstOrNull { it.flow.equals(analyticsEvent.flow, false) }?.severityLevel ?: 0
+                ).firstOrNull { it.flow.equals(analyticsEvent.flow, true) }?.severityLevel ?: 0
 
         return savedSeverityLevel >= analyticsEvent.severityLevel
     }

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/severity/SdkAnalyticsSeverityUtils.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/severity/SdkAnalyticsSeverityUtils.kt
@@ -7,13 +7,10 @@ class SdkAnalyticsSeverityUtils {
 
     fun isEventSeverityAllowed(analyticsEvent: AnalyticsEvent): Boolean {
         val savedSeverityLevel =
-            if (SdkAnalyticsUtils.analyticsFlowSeverityLevels == null) {
-                5
-            } else {
-                SdkAnalyticsUtils.analyticsFlowSeverityLevels?.firstOrNull {
-                    it.flow.equals(analyticsEvent.flow, false)
-                }?.severityLevel ?: 0
-            }
+            (
+                SdkAnalyticsUtils.analyticsFlowSeverityLevels
+                    ?: SdkAnalyticsUtils.defaultAnalyticsFlowSeverityLevels
+                ).firstOrNull { it.flow.equals(analyticsEvent.flow, false) }?.severityLevel ?: 0
 
         return savedSeverityLevel >= analyticsEvent.severityLevel
     }

--- a/appcoins-core/src/test/java/com/appcoins/sdk/core/analytics/SdkAnalyticsTest.kt
+++ b/appcoins-core/src/test/java/com/appcoins/sdk/core/analytics/SdkAnalyticsTest.kt
@@ -2,23 +2,40 @@ package com.appcoins.sdk.core.analytics
 
 import android.content.Context
 import com.appcoins.sdk.core.analytics.events.SdkAppUpdateAvailableEvents
+import com.appcoins.sdk.core.analytics.events.SdkAppUpdateAvailableEvents.APP_UPDATE_AVAILABLE_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkBackendRequestEvents
+import com.appcoins.sdk.core.analytics.events.SdkBackendRequestEvents.BACKEND_REQUEST_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkBackendRequestType
 import com.appcoins.sdk.core.analytics.events.SdkConsumePurchaseEvents
+import com.appcoins.sdk.core.analytics.events.SdkConsumePurchaseEvents.CONSUME_PURCHASE_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkGeneralFailureEvents
+import com.appcoins.sdk.core.analytics.events.SdkGeneralFailureEvents.GENERAL_FAILURE_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkGeneralFailureStep
 import com.appcoins.sdk.core.analytics.events.SdkGetReferralDeeplinkEvents
+import com.appcoins.sdk.core.analytics.events.SdkGetReferralDeeplinkEvents.GET_REFERRAL_DEEPLINK_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkInitializationEvents
+import com.appcoins.sdk.core.analytics.events.SdkInitializationEvents.SDK_INITIALIZATION_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkInstallWalletDialogEvents
+import com.appcoins.sdk.core.analytics.events.SdkInstallWalletDialogEvents.INSTALL_WALLET_DIALOG_FLOW
+import com.appcoins.sdk.core.analytics.events.SdkIsFeatureSupportedEvents.IS_FEATURE_SUPPORTED_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkLaunchAppUpdateDialogEvents
+import com.appcoins.sdk.core.analytics.events.SdkLaunchAppUpdateDialogEvents.LAUNCH_APP_UPDATE_DIALOG_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkLaunchAppUpdateEvents
+import com.appcoins.sdk.core.analytics.events.SdkLaunchAppUpdateEvents.LAUNCH_APP_UPDATE_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkLaunchAppUpdateStoreEvents
+import com.appcoins.sdk.core.analytics.events.SdkLaunchAppUpdateStoreEvents.LAUNCH_APP_UPDATE_STORE_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkPurchaseFlowEvents
+import com.appcoins.sdk.core.analytics.events.SdkPurchaseFlowEvents.PURCHASE_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkQueryPurchasesEvents
+import com.appcoins.sdk.core.analytics.events.SdkQueryPurchasesEvents.SDK_QUERY_PURCHASES_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkQuerySkuDetailsEvents
+import com.appcoins.sdk.core.analytics.events.SdkQuerySkuDetailsEvents.QUERY_SKU_DETAILS_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkWalletPaymentFlowEvents
+import com.appcoins.sdk.core.analytics.events.SdkWalletPaymentFlowEvents.WALLET_PAYMENT_FLOW
 import com.appcoins.sdk.core.analytics.events.SdkWebPaymentFlowEvents
+import com.appcoins.sdk.core.analytics.events.SdkWebPaymentFlowEvents.WEB_PAYMENT_FLOW
 import com.appcoins.sdk.core.analytics.manager.AnalyticsManager
+import com.appcoins.sdk.core.analytics.severity.AnalyticsFlowSeverityLevel
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -40,6 +57,25 @@ class SdkAnalyticsTest {
     @Before
     fun setup() {
         sdkAnalytics = SdkAnalytics(mockkAnalyticsManager)
+        SdkAnalyticsUtils.isAnalyticsSetupFromPayflowFinalized = true
+        SdkAnalyticsUtils.analyticsFlowSeverityLevels = FULL_SEVERITY_LEVELS
+    }
+
+    @Test
+    fun `should not send event if Payflow message not received yet`() {
+        SdkAnalyticsUtils.isAnalyticsSetupFromPayflowFinalized = false
+        val analyticsEvent = SdkAppUpdateAvailableEvents.SdkAppUpdateAvailableRequest()
+
+        sdkAnalytics.sendAppUpdateAvailableRequest()
+
+        verify(exactly = 0) {
+            mockkAnalyticsManager.logEvent(
+                any(),
+                analyticsEvent.name,
+                analyticsEvent.action,
+                EVENT_CONTEXT
+            )
+        }
     }
 
     @Test
@@ -996,7 +1032,7 @@ class SdkAnalyticsTest {
             )
         } just runs
 
-        sdkAnalytics.sendPurchaseResultEvent(DEFAULT_INTEGER, EMPTY_STRING, EMPTY_STRING)
+        sdkAnalytics.sendPurchaseResultEvent(DEFAULT_INTEGER, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING)
 
         verify(exactly = 1) {
             mockkAnalyticsManager.logEvent(
@@ -1519,5 +1555,24 @@ class SdkAnalyticsTest {
         const val DEFAULT_INTEGER = 1
         const val DEFAULT_BOOLEAN = true
         val DEFAULT_MAP = mutableMapOf<String, Any>()
+
+        val FULL_SEVERITY_LEVELS = listOf(
+            AnalyticsFlowSeverityLevel(flow = APP_UPDATE_AVAILABLE_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = BACKEND_REQUEST_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = CONSUME_PURCHASE_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = GENERAL_FAILURE_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = GET_REFERRAL_DEEPLINK_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = SDK_INITIALIZATION_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = INSTALL_WALLET_DIALOG_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = IS_FEATURE_SUPPORTED_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = LAUNCH_APP_UPDATE_DIALOG_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = LAUNCH_APP_UPDATE_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = LAUNCH_APP_UPDATE_STORE_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = PURCHASE_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = SDK_QUERY_PURCHASES_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = QUERY_SKU_DETAILS_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = WALLET_PAYMENT_FLOW, 5),
+            AnalyticsFlowSeverityLevel(flow = WEB_PAYMENT_FLOW, 5),
+        )
     }
 }

--- a/appcoins-core/src/test/java/com/appcoins/sdk/core/analytics/severity/SdkAnalyticsSeverityUtilsTest.kt
+++ b/appcoins-core/src/test/java/com/appcoins/sdk/core/analytics/severity/SdkAnalyticsSeverityUtilsTest.kt
@@ -2,6 +2,7 @@ package com.appcoins.sdk.core.analytics.severity
 
 import com.appcoins.sdk.core.analytics.SdkAnalyticsUtils
 import com.appcoins.sdk.core.analytics.events.SdkInitializationEvents
+import com.appcoins.sdk.core.analytics.events.SdkPurchaseFlowEvents
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,10 +22,20 @@ class SdkAnalyticsSeverityUtilsTest {
     }
 
     @Test
-    fun `should return true when no severity levels defined`() {
+    fun `should return false for SdkInitializationEvents when no severity levels defined`() {
         SdkAnalyticsUtils.analyticsFlowSeverityLevels = null
 
         val result = sdkAnalyticsSeverityUtils.isEventSeverityAllowed(SdkInitializationEvents.SdkStartConnection())
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `should return false for Sdk when no severity levels defined`() {
+        SdkAnalyticsUtils.analyticsFlowSeverityLevels = null
+
+        val result =
+            sdkAnalyticsSeverityUtils.isEventSeverityAllowed(SdkPurchaseFlowEvents.SdkLaunchPurchaseMainThreadFailure())
 
         assertTrue(result)
     }


### PR DESCRIPTION
**What does this PR do?**

This task was done to have a better control of the initial Log Verbosity with a default more appropriate and a caching mechanism to store events before receiving the Log Verbosity level from Payflow SDK.

**What are the relevant tickets?**

Tickets related to this pull-request:
- [APT-4694](https://aptoide.atlassian.net/browse/APT-4694)

**Questions:**

Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass