### PR TITLE
Verify "Don't keep activities" status

### DIFF
--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/managers/BillingLifecycleManager.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/managers/BillingLifecycleManager.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import com.appcoins.sdk.billing.payflow.PayflowManager
 import com.appcoins.sdk.billing.receivers.AppInstallationReceiver
+import com.appcoins.sdk.billing.usecases.VerifyDontKeepActivitiesStatus
 import com.appcoins.sdk.core.logger.Logger.logError
 
 object BillingLifecycleManager {
@@ -26,6 +27,7 @@ object BillingLifecycleManager {
                 appInstallationReceiver,
                 receiverIntentFilter
             )
+            VerifyDontKeepActivitiesStatus()
         }.start()
     }
 

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/sharedpreferences/SystemSharedPreferences.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/sharedpreferences/SystemSharedPreferences.kt
@@ -1,0 +1,15 @@
+package com.appcoins.sdk.billing.sharedpreferences
+
+import android.content.Context
+
+@Suppress("complexity:TooManyFunctions")
+class SystemSharedPreferences(context: Context) : SharedPreferencesRepository(context) {
+
+    fun isDontKeepActivitiesEventSent(): Boolean = getBoolean(DONT_KEEP_ACTIVITIES_EVENT_KEY)
+
+    fun sendDontKeepActivitiesEvent() = setBoolean(DONT_KEEP_ACTIVITIES_EVENT_KEY, true)
+
+    private companion object {
+        const val DONT_KEEP_ACTIVITIES_EVENT_KEY = "DONT_KEEP_ACTIVITIES_EVENT"
+    }
+}

--- a/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/usecases/VerifyDontKeepActivitiesStatus.kt
+++ b/android-appcoins-billing/src/main/java/com/appcoins/sdk/billing/usecases/VerifyDontKeepActivitiesStatus.kt
@@ -1,0 +1,47 @@
+package com.appcoins.sdk.billing.usecases
+
+import android.content.ContentResolver
+import android.content.Context
+import android.provider.Settings
+import com.appcoins.sdk.billing.helpers.WalletUtils
+import com.appcoins.sdk.billing.sharedpreferences.SystemSharedPreferences
+import com.appcoins.sdk.core.analytics.SdkAnalyticsUtils
+import com.appcoins.sdk.core.logger.Logger.logInfo
+
+object VerifyDontKeepActivitiesStatus : UseCase() {
+
+    private val systemSharedPreferences: SystemSharedPreferences by lazy {
+        SystemSharedPreferences(WalletUtils.context)
+    }
+
+    operator fun invoke() {
+        super.invokeUseCase()
+
+        val isDontKeepActivitiesEventSent = systemSharedPreferences.isDontKeepActivitiesEventSent()
+
+        if (!isDontKeepActivitiesEventSent) {
+            val isAlwaysFinishActivitiesEnabled = isAlwaysFinishActivitiesEnabled(WalletUtils.context)
+            if (isAlwaysFinishActivitiesEnabled) {
+                logInfo("Always finish activities is enabled. Sending dont keep activities event.")
+                systemSharedPreferences.sendDontKeepActivitiesEvent()
+                sendDontKeepActivitiesEvent()
+            }
+        } else {
+            logInfo("Dont keep activities event is already sent.")
+        }
+    }
+
+    private fun sendDontKeepActivitiesEvent() {
+        SdkAnalyticsUtils.sdkAnalytics.sendDoNotKeepActivitiesEvent()
+    }
+
+    private fun isAlwaysFinishActivitiesEnabled(context: Context): Boolean {
+        val resolver: ContentResolver = context.contentResolver
+        val state = Settings.Global.getInt(
+            resolver,
+            Settings.Global.ALWAYS_FINISH_ACTIVITIES,
+            0
+        )
+        return state != 0
+    }
+}

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/AnalyticsManagerProvider.java
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/AnalyticsManagerProvider.java
@@ -14,6 +14,7 @@ import com.appcoins.sdk.core.analytics.events.SdkLaunchAppUpdateStoreEvents;
 import com.appcoins.sdk.core.analytics.events.SdkPurchaseFlowEvents;
 import com.appcoins.sdk.core.analytics.events.SdkQueryPurchasesEvents;
 import com.appcoins.sdk.core.analytics.events.SdkQuerySkuDetailsEvents;
+import com.appcoins.sdk.core.analytics.events.SdkSystemInformationEvents;
 import com.appcoins.sdk.core.analytics.events.SdkWalletPaymentFlowEvents;
 import com.appcoins.sdk.core.analytics.events.SdkWebPaymentFlowEvents;
 import com.appcoins.sdk.core.analytics.indicative.IndicativeEventLogger;
@@ -107,6 +108,7 @@ public class AnalyticsManagerProvider {
         list.add(SdkWebPaymentFlowEvents.SDK_WEB_PAYMENT_EXECUTE_EXTERNAL_DEEPLINK);
         list.add(SdkWebPaymentFlowEvents.SDK_WEB_PAYMENT_ERROR_PROCESSING_PURCHASE_RESULT);
         list.add(SdkWebPaymentFlowEvents.SDK_WEB_PAYMENT_PURCHASE_RESULT_EMPTY);
+        list.add(SdkSystemInformationEvents.SDK_DO_NOT_KEEP_ACTIVITIES_ACTIVE);
         return list;
     }
 }

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/SdkAnalytics.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/SdkAnalytics.kt
@@ -31,6 +31,7 @@ import com.appcoins.sdk.core.analytics.events.SdkQueryPurchasesEvents
 import com.appcoins.sdk.core.analytics.events.SdkQueryPurchasesLabels
 import com.appcoins.sdk.core.analytics.events.SdkQuerySkuDetailsEvents
 import com.appcoins.sdk.core.analytics.events.SdkQuerySkuDetailsLabels
+import com.appcoins.sdk.core.analytics.events.SdkSystemInformationEvents
 import com.appcoins.sdk.core.analytics.events.SdkWalletPaymentFlowEvents
 import com.appcoins.sdk.core.analytics.events.SdkWebPaymentFlowEvents
 import com.appcoins.sdk.core.analytics.events.SdkWebPaymentFlowLabels
@@ -592,6 +593,11 @@ class SdkAnalytics(private val analyticsManager: AnalyticsManager) {
         eventData[SdkQuerySkuDetailsLabels.SKU_TYPE] = skuType
 
         logEvent(SdkQuerySkuDetailsEvents.SdkQuerySkuDetailsFailureParsingSkus(eventData))
+    }
+
+    // System Information events
+    fun sendDoNotKeepActivitiesEvent() {
+        logEvent(SdkSystemInformationEvents.SdkDoNotKeepActivitiesActive())
     }
 
     private fun addBackendRequestData(

--- a/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkSystemInformationEvents.kt
+++ b/appcoins-core/src/main/java/com/appcoins/sdk/core/analytics/events/SdkSystemInformationEvents.kt
@@ -1,0 +1,19 @@
+package com.appcoins.sdk.core.analytics.events
+
+import com.appcoins.sdk.core.analytics.manager.AnalyticsManager
+
+object SdkSystemInformationEvents {
+
+    class SdkDoNotKeepActivitiesActive :
+        AnalyticsEvent(
+            AnalyticsManager.Action.IMPRESSION,
+            SDK_DO_NOT_KEEP_ACTIVITIES_ACTIVE,
+            mutableMapOf(),
+            SYSTEM_INFORMATION_FLOW,
+            1
+        )
+
+    const val SDK_DO_NOT_KEEP_ACTIVITIES_ACTIVE = "sdk_do_not_keep_activities_active"
+
+    const val SYSTEM_INFORMATION_FLOW = "system_information"
+}


### PR DESCRIPTION
**What does this PR do?**

This PR introduces a mechanism to detect if the "Don't keep activities" developer setting is enabled on the user's device.
If this setting is active, an analytics event (`sdk_do_not_keep_activities_active`) is sent to track its usage. This event is only sent once per device.
The detection and event sending logic is encapsulated in the new `VerifyDontKeepActivitiesStatus` use case and utilizes `SystemSharedPreferences` to persist whether the event has already been sent.

**What are the relevant tickets?**

Tickets related to this pull-request:
- [ATS-1673](https://aptoide.atlassian.net/browse/ATS-1673)

**Questions:**

Does this add new dependencies which need to be added? (Eg. new libs, new keys, etc.)

**Code Review Checklist**

- [ ] Architecture
- [ ] Documentation on public interfaces
- [ ] Database changed?
- [ ] If yes - Database migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] Functional QA tests pass
